### PR TITLE
Fix issues related to clusters with pod security policies

### DIFF
--- a/charts/telepresence/templates/pre-delete-hook.yaml
+++ b/charts/telepresence/templates/pre-delete-hook.yaml
@@ -25,6 +25,8 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
         helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     spec:
+      serviceAccount: traffic-manager
+      serviceAccountName: traffic-manager
       securityContext:
         {{- toYaml .Values.hooks.podSecurityContext | nindent 8 }}
       restartPolicy: Never

--- a/charts/telepresence/templates/trafficManagerRbac/cluster-scope.yaml
+++ b/charts/telepresence/templates/trafficManagerRbac/cluster-scope.yaml
@@ -66,6 +66,9 @@ rules:
   - list
   - patch
   - update # Only needed for upgrade of older versions
+{{- range .Values.additionalRules }}
+- {{ toYaml . | nindent 2 | trim }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/telepresence/values.yaml
+++ b/charts/telepresence/values.yaml
@@ -296,3 +296,14 @@ hooks:
     registry: docker.io
     image: "curlimages/curl"
     tag: latest
+
+# Additional rules for the traffic-manager service account e.g. pod security policies.
+additionalRules: []
+  # - apiGroups:
+  #   - policy
+  #   resourceNames:
+  #   - admin
+  #   resources:
+  #   - podsecuritypolicies
+  #   verbs:
+  #   - use


### PR DESCRIPTION
- Add traffic-manager service account to pre-delete-hook.
- Add additionalRules field to ClusterRole, so that things like PodSecurityPolicies can be set.